### PR TITLE
fixed dep in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ TRON exposes very few functions, here is a small example:
 The easiest way to use TRON in your own projects is via Leiningen.
 Add the following dependency to your project.clj file:
 
-    [spootnik/tron   "0.5.4"]
+    [tron "0.5.4"]
 
 If you would rather use maven, you need to specify the clojars
 repository dependency and import the tron artifact


### PR DESCRIPTION
`[spootnik/tron "0.5.4"]` didn't find dep, it seems that it is `[tron "0.5.4"]` in clojars.
